### PR TITLE
add step for installing NVIDIA bindings

### DIFF
--- a/doc_source/tutorial-gpu-monitoring-gpumon.md
+++ b/doc_source/tutorial-gpu-monitoring-gpumon.md
@@ -51,6 +51,12 @@ For more information on creating an IAM user and adding policies for CloudWatch,
    $ source activate python2
    ```
 
+1. Install the [NVIDIA Python bindings](https://pypi.org/project/nvidia-ml-py/). The script uses these to access GPU monitoring functions.
+
+   ```
+   $ pip install nvidia-ml-py
+   ```
+
 1. Run the gpumon utility in background\.
 
    ```


### PR DESCRIPTION
*Issue #, if available:*

When running the `gpumon.py` script on Deep Learning AMI (Amazon Linux 2) Version 22.0 (ami-02691eea9fd224ffd) via the provided instructions, I encountered this error:
```
Traceback (most recent call last):
  File "gpumon.py", line 17, in <module>
    from pynvml import *
ImportError: No module named pynvml
```

*Description of changes:*

This PR adds the missing step to the provided instructions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
