### PR TITLE
Fix "Use Apache MXNet for Inference with an ONNX Model" tutorial

### DIFF
--- a/doc_source/tutorial-mxnet-inference-onnx.md
+++ b/doc_source/tutorial-mxnet-inference-onnx.md
@@ -27,11 +27,18 @@
    ```
    $ curl -O https://gist.githubusercontent.com/yrevar/6135f1bd8dcf2e0cc683/raw/d133d61a09d7e5a3b36b8c111a8dd5c4b5d560ee/imagenet1000_clsid_to_human.pkl
    ```
+   
+1. Download the VGG 16 model in ONNX format\.
+
+   ```
+   $ wget -O vgg16.onnx https://github.com/onnx/models/raw/master/vision/classification/vgg/model/vgg16-7.onnx
+   ```
 
 1. Use a your preferred text editor to create a script that has the following content\. This script will use the image of the husky, get a prediction result from the pre\-trained model, then look this up in the file of classes, returning a prediction result\.
 
    ```
    import mxnet as mx
+   import mxnet.contrib.onnx as onnx_mxnet
    import numpy as np
    from collections import namedtuple
    from PIL import Image

--- a/doc_source/tutorial-mxnet-inference-onnx.md
+++ b/doc_source/tutorial-mxnet-inference-onnx.md
@@ -22,19 +22,19 @@
    $ curl -O https://upload.wikimedia.org/wikipedia/commons/b/b5/Siberian_Husky_bi-eyed_Flickr.jpg
    ```
 
-1. Download a list of classes will work with this model\.
+1. Download a list of classes that will work with this model\.
 
    ```
    $ curl -O https://gist.githubusercontent.com/yrevar/6135f1bd8dcf2e0cc683/raw/d133d61a09d7e5a3b36b8c111a8dd5c4b5d560ee/imagenet1000_clsid_to_human.pkl
    ```
    
-1. Download the VGG 16 model in ONNX format\.
+1. Download the pre-trained VGG 16 model in ONNX format\.
 
    ```
    $ wget -O vgg16.onnx https://github.com/onnx/models/raw/master/vision/classification/vgg/model/vgg16-7.onnx
    ```
 
-1. Use a your preferred text editor to create a script that has the following content\. This script will use the image of the husky, get a prediction result from the pre\-trained model, then look this up in the file of classes, returning a prediction result\.
+1. Use your preferred text editor to create a script that has the following content\. This script will use the image of the husky, get a prediction result from the pre\-trained model, then look this up in the file of classes, returning an image classification\.
 
    ```
    import mxnet as mx


### PR DESCRIPTION
*Description of changes:* Currently, if users run the code provided in [this blog post](https://docs.aws.amazon.com/dlami/latest/devguide/tutorial-mxnet-inference-onnx.html) they will encounter errors. The first error the user will encounter is `NameError: name 'onnx_mxnet' is not defined` - this is due to the fact that `onnx_mxnet` is not imported. After properly importing `onnx_mxnet`, the second error the user will encounter is `FileNotFoundError: [Errno 2] No such file or directory: 'vgg16.onnx'` - this is due to the fact that the VGG 16 model has not yet been downloaded to the user's working directory. My changes in this pull request fix both of these issues and update the phrasing of some of the text in the tutorial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@sandeep-krishnamurthy @aaronmarkham