### PR TITLE
Remove initial [confusing] references to "Graviton GPU"

### DIFF
--- a/doc_source/tutorial-graviton-pytorch.md
+++ b/doc_source/tutorial-graviton-pytorch.md
@@ -1,6 +1,6 @@
-# Using the Graviton GPU PyTorch DLAMI<a name="tutorial-graviton-pytorch"></a>
+# Using the PyTorch DLAMI with AWS Graviton\-based EC2 instances featuring GPUs<a name="tutorial-graviton-pytorch"></a>
 
-The AWS Deep Learning AMI is ready to use with Arm processor\-based Graviton GPUs, and comes optimized for PyTorch\. The Graviton GPU PyTorch DLAMI includes a Python environment pre\-configured with [PyTorch](http://aws.amazon.com/pytorch), [TorchVision](https://pytorch.org/vision/stable/index.html), and [TorchServe](https://pytorch.org/serve/) for deep learning training and inference use cases\. Check the [release notes](http://aws.amazon.com/releasenotes/deep-learning-ami-graviton-gpu-pytorch-1-10-ubuntu-20-04/) for additional details on the Graviton GPU PyTorch DLAMI\.
+The AWS Deep Learning AMI is ready to use with AWS Graviton\-based EC2 instances featuring GPUs, and comes optimized for PyTorch\. The Graviton GPU PyTorch DLAMI includes a Python environment pre\-configured with [PyTorch](http://aws.amazon.com/pytorch), [TorchVision](https://pytorch.org/vision/stable/index.html), and [TorchServe](https://pytorch.org/serve/) for deep learning training and inference use cases\. Check the [release notes](http://aws.amazon.com/releasenotes/deep-learning-ami-graviton-gpu-pytorch-1-10-ubuntu-20-04/) for additional details on the Graviton GPU PyTorch DLAMI\.
 
 **Topics**
 + [Verify PyTorch Python Environment](#tutorial-graviton-pytorch-environment)


### PR DESCRIPTION
*Description of changes:*

AWS Graviton is the brand for AWS Arm-based general purpose processors, using the term "Graviton GPU" is misleading... there is no such thing as a Graviton GPU. I get that the DLAMI is being referred to as the "Graviton GPU PyTorch DLAMI" but we can be clear in the page title and opening paragraph that Graviton is not a GPU with the proposed changes here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
